### PR TITLE
Removes profile apache.snapshots that does not exist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                   artifactsPublisher(disabled: true),
                   findbugsPublisher(disabled: true),
                 ]) {
-                    sh "mvn -ntp -V -e -Preporting -Papache.snapshots -Dscreenshot=false clean install site"
+                    sh "mvn -ntp -V -e -Preporting -Dscreenshot=false clean install site"
                 }
             }
         }


### PR DESCRIPTION
> [WARNING] The requested profile "apache.snapshots" could not be activated because it does not exist.