### PR TITLE
Disable chek index page for Maven parent

### DIFF
--- a/src/main/resources/dist-tool.conf
+++ b/src/main/resources/dist-tool.conf
@@ -159,10 +159,10 @@
 > apache site = https://maven.apache.org/pom/asf/
   apache
 
-/pom: org.apache.maven https://maven.apache.org/pom/
-> maven-parent index-path = /maven/
-> maven-parent site = https://maven.apache.org/pom/maven/
-  maven-parent
+## /pom: org.apache.maven https://maven.apache.org/pom/
+## > maven-parent index-path = /maven/
+## > maven-parent site = https://maven.apache.org/pom/maven/
+##   maven-parent
 
 #### disable release check waiting for 3.0.1: confusion between old 3 and current 3.0.0
 ####/release: org.apache.maven.release


### PR DESCRIPTION
We have an error:

```
maven-parent: found null instead of 45 in https://maven.apache.org/pom/
```