### PR TITLE
Add missing license headers and configuration updates

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Daether.remoteRepositoryFilter.prefixes.resolvePrefixFiles.repo.jenkins-ci.org=false

--- a/check-plugins-maven4.sh
+++ b/check-plugins-maven4.sh
@@ -1,5 +1,22 @@
 #!/bin/env bash
 
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 # repo init -u https://github.com/apache/maven-sources.git
 SRC=$(pwd)/../../plugins
 

--- a/src/main/resources/dist-tool.conf
+++ b/src/main/resources/dist-tool.conf
@@ -74,7 +74,7 @@
 ##  apache-maven [3.3.0,3.4.0-alpha-1)
 ##  apache-maven [3.5.0,3.6.0-alpha-1)
 ##  apache-maven [3.6.0,3.7.0-alpha-1)
-  apache-maven [3.8.0,3.9.0-alpha-1)
+##  apache-maven [3.8.0,3.9.0-alpha-1)
   apache-maven [3.9.0,3.10.0-alpha-1)
 
 /maven-4: org.apache.maven src+bin

--- a/src/site/markdown/plugins-maven4.md
+++ b/src/site/markdown/plugins-maven4.md
@@ -1,3 +1,21 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 # Maven 3 Plugins Build Results for Maven 4 Compatibility Check
 
 WIP (should be in [Maven 4.0.0-RC6](https://github.com/apache/maven/milestone/127)):


### PR DESCRIPTION
- Added ASF license headers to scripts and documentation files.
- Commented out an outdated Maven version range in `dist-tool.conf`.
- Introduced `.mvn/maven.config` with block prefixes from jankins repo