### PR TITLE
Replace MavenProjectBuilder with ProjectBuilder and drop maven-compat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mvnversion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-repository-metadata</artifactId>
       <version>${mvnversion}</version>
       <scope>provided</scope>

--- a/src/main/java/org/apache/maven/dist/tools/site/DistCheckSiteReport.java
+++ b/src/main/java/org/apache/maven/dist/tools/site/DistCheckSiteReport.java
@@ -29,11 +29,14 @@ import org.apache.maven.dist.tools.AbstractDistCheckReport;
 import org.apache.maven.dist.tools.ConfigurationLineInfo;
 import org.apache.maven.dist.tools.JsoupRetry;
 import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.reporting.MavenReportException;
 import org.jsoup.HttpStatusException;
 import org.jsoup.nodes.Document;
@@ -75,7 +78,10 @@ public class DistCheckSiteReport extends AbstractDistCheckReport {
      * Maven project builder.
      */
     @Component
-    protected MavenProjectBuilder mavenProjectBuilder;
+    protected ProjectBuilder projectBuilder;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    protected MavenSession session;
 
     /**
      * Http status ok code.
@@ -227,8 +233,12 @@ public class DistCheckSiteReport extends AbstractDistCheckReport {
         results.add(result);
         try {
             Artifact artifact = artifactFactory.createProjectArtifact(cli.getGroupId(), cli.getArtifactId(), version);
+            ProjectBuildingRequest request = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+            request.setRemoteRepositories(artifactRepositories);
+            request.setLocalRepository(localRepository);
+            request.setProcessPlugins(false);
             MavenProject artifactProject =
-                    mavenProjectBuilder.buildFromRepository(artifact, artifactRepositories, localRepository, false);
+                    projectBuilder.build(artifact, false, request).getProject();
 
             String siteUrl = sites.get(cli.getArtifactId());
             if (siteUrl == null) {


### PR DESCRIPTION
`MavenProjectBuilder` is the Maven 2 interface and lives only in `maven-compat`. `ProjectBuilder` in maven-core does the same job, and there was exactly one call site.

```java
- MavenProject artifactProject =
-         mavenProjectBuilder.buildFromRepository(artifact, artifactRepositories, localRepository, false);
+ ProjectBuildingRequest request = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+ request.setRemoteRepositories(artifactRepositories);
+ request.setLocalRepository(localRepository);
+ request.setProcessPlugins(false);
+ MavenProject artifactProject =
+         projectBuilder.build(artifact, false, request).getProject();
```

Three notes on faithfulness:

- The trailing `false` is `allowStubModel`, and `ProjectBuilder` has a `build(Artifact, boolean, ProjectBuildingRequest)` overload that takes it, so that behaviour is unchanged rather than approximated.
- The request derives from `session.getProjectBuildingRequest()`, so it inherits the repository session, offline mode and the rest instead of starting from a bare one.
- `setProcessPlugins(false)` keeps the old behaviour — these reads never processed plugins.

The `session` parameter is new; the mojo had no reason to hold one before.

**`ArtifactFactory` stays.** Despite the name it lives in maven-core, not maven-compat, so it is not part of this.

**Verified:** `mvn verify` clean before and after.

Part of a survey of which projects still declare `maven-compat` versus which genuinely need it. Related, if you want the context: apache/maven#12709 covers the baseline question that blocks several of the others.
