### PR TITLE
Pin Maven prerequisite to 3.6.3 instead of ${mvnversion}

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   <url>https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-dist-tool/job/master/site/index.html</url>
 
   <prerequisites>
-    <maven>${mvnversion}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <scm>


### PR DESCRIPTION
`${mvnversion}` also sets the maven-core dependency version, so the declared baseline had drifted to 3.9.16. Pinned back to 3.6.3 like the rest of the 3.x line; `jdeps` against a 3.6.3 stack finds nothing missing.

<sub>Drafted with Claude — please verify</sub>
